### PR TITLE
Check if socket exists before attempting to close

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -82,7 +82,9 @@ export class Client extends EventEmitter implements IClient {
      * Closes and frees the resources ascociated with the interactive connection.
      */
     public close() {
-        this.socket.close();
+        if (this.socket) {
+            this.socket.close();
+        }
     }
 
     //TODO: Actually implement compression


### PR DESCRIPTION
Fixes an issue I was encountering duing rapid reconnections where the socket was undefined when attempting to close it.