### PR TITLE
Resolve GitHub issue #64: "Maintain a list of frontend grid sizes and export them"

### DIFF
--- a/src/InteractiveConstants.ts
+++ b/src/InteractiveConstants.ts
@@ -1,0 +1,29 @@
+import { IGridLayout } from './state/interfaces/controls';
+
+/**
+ * Offers constant information values to use in an application.
+ */
+export class InteractiveConstants {
+    private static readonly _gridLayoutSizes: IGridLayout[] = [
+        {
+            size: 'large',
+            width: 80,
+            height: 20,
+        }, {
+            size: 'medium',
+            width: 45,
+            height: 25,
+        }, {
+            size: 'small',
+            width: 30,
+            height: 40,
+        },
+    ];
+
+	/**
+     * @returns {{GridLayout[]}} a copy of the stored layout definitions to prevent users from breaking it.
+	 */
+	public static get gridLayoutSizes(): IGridLayout[] {
+        return {...InteractiveConstants._gridLayoutSizes};
+    }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,8 +3,8 @@ import { IGridLayout } from './state/interfaces/controls';
 /**
  * Offers constant information values to use in an application.
  */
-export class InteractiveConstants {
-    private static readonly _gridLayoutSizes: IGridLayout[] = [
+export module InteractiveConstants {
+    export const gridLayoutSizes: IGridLayout[] = <IGridLayout[]> Object.freeze([
         {
             size: 'large',
             width: 80,
@@ -18,12 +18,5 @@ export class InteractiveConstants {
             width: 30,
             height: 40,
         },
-    ];
-
-	/**
-     * @returns {{GridLayout[]}} a copy of the stored layout definitions to prevent users from breaking it.
-	 */
-	public static get gridLayoutSizes(): IGridLayout[] {
-        return {...InteractiveConstants._gridLayoutSizes};
-    }
+    ]);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,9 @@ export * from './state/Group';
 export * from './IClient';
 export * from './GameClient';
 export * from './ParticipantClient';
-export * from './InteractiveConstants';
-export * from './util';
+export * from './constants';
 export * from './errors';
+export * from './util';
 
 /**
  * This allows you to specify which WebSocket implementation your

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './state/Group';
 export * from './IClient';
 export * from './GameClient';
 export * from './ParticipantClient';
+export * from './InteractiveConstants';
 export * from './util';
 export * from './errors';
 

--- a/src/state/interfaces/controls/IControl.ts
+++ b/src/state/interfaces/controls/IControl.ts
@@ -8,6 +8,12 @@ import { IMeta } from './IMeta';
 export type ControlKind = 'button' | 'joystick';
 export type GridSize = 'large' | 'medium' | 'small';
 
+export interface IGridLayout {
+    readonly size: GridSize;
+    readonly width: number;
+    readonly height: number;
+}
+
 /**
  * Represents the raw data a control has when transmitted
  * and received over a socket connection.


### PR DESCRIPTION
This is an attempt to resolve issue #64 "Maintain a list of frontend grid sizes and export them".
I'm not sure if the method of how this is implemented is the best way, but I think it's okay.
I made it so that the information exported cannot be overridden.