### PR TITLE
Added the participant object as a second parameter to the onParticipantLeave event

### DIFF
--- a/docs/interfaces/istate.html
+++ b/docs/interfaces/istate.html
@@ -600,6 +600,9 @@
 														<li>
 															<h5>participantSessionID: <span class="tsd-signature-type">string</span></h5>
 														</li>
+														<li>
+															<h5>participant: <span class="tsd-signature-type">IParticipant</span></h5>
+														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 												</li>

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -6,6 +6,7 @@ import {
     IButton,
     IButtonData,
     IControlData,
+    IParticipant,
     setWebSocket,
 } from '../lib';
 
@@ -108,7 +109,7 @@ client.open({
 client.state.on('participantJoin', participant => {
     console.log(`${participant.username}(${participant.sessionID}) Joined`);
 });
-client.state.on('participantLeave', (participant: string ) => {
-    console.log(`${participant} Left`);
+client.state.on('participantLeave', (participantSessionID: string, participant: IParticipant ) => {
+    console.log(`${participant.username}(${participantSessionID}) Left`);
 });
 /* tslint:enable:no-console */

--- a/examples/dynamicControls.ts
+++ b/examples/dynamicControls.ts
@@ -104,7 +104,7 @@ client.open({
 client.state.on('participantJoin', (participant: IParticipant ) => {
     console.log(`${participant.username}(${participant.sessionID}) Joined`);
 });
-client.state.on('participantLeave', (participant: string ) => {
-    console.log(`${participant} Left`);
+client.state.on('participantLeave', (participantSessionID: string, participant: IParticipant ) => {
+    console.log(`${participant.username}(${participantSessionID}) Left`);
 });
 /* tslint:enable:no-console */

--- a/examples/groups.ts
+++ b/examples/groups.ts
@@ -199,6 +199,6 @@ client.state.on('participantJoin', (participant: IParticipant ) => {
 
 client.state.on('participantLeave', (participantSessionID: string, participant: IParticipant ) => {
     console.log(`${participant.username}(${participantSessionID}) Left`);
-    removeParticipant(participant)
+    removeParticipant(participantSessionID)
 });
 /* tslint:enable:no-console */

--- a/examples/groups.ts
+++ b/examples/groups.ts
@@ -197,8 +197,8 @@ client.state.on('participantJoin', (participant: IParticipant ) => {
     }
 });
 
-client.state.on('participantLeave', (participant: string ) => {
-    console.log(`${participant} Left`);
+client.state.on('participantLeave', (participantSessionID: string, participant: IParticipant ) => {
+    console.log(`${participant.username}(${participantSessionID}) Left`);
     removeParticipant(participant)
 });
 /* tslint:enable:no-console */

--- a/examples/joystick.ts
+++ b/examples/joystick.ts
@@ -5,6 +5,7 @@ import {
     GameClient,
     IJoystick,
     IJoystickData,
+    IParticipant,
     setWebSocket,
 } from '../lib';
 
@@ -85,7 +86,7 @@ client.open({
 client.state.on('participantJoin', participant => {
     console.log(`${participant.username}(${participant.sessionID}) Joined`);
 });
-client.state.on('participantLeave', (participant: string ) => {
-    console.log(`${participant} Left`);
+client.state.on('participantLeave', (participantSessionID: string, participant: IParticipant ) => {
+    console.log(`${participant.username}(${participantSessionID}) Left`);
 });
 /* tslint:enable:no-console */

--- a/examples/updateControl.ts
+++ b/examples/updateControl.ts
@@ -6,6 +6,7 @@ import {
     IButton,
     IButtonData,
     IControlData,
+    IParticipant,
     setWebSocket,
 } from '../lib';
 
@@ -111,7 +112,7 @@ client.open({
 client.state.on('participantJoin', participant => {
     console.log(`${participant.username}(${participant.sessionID}) Joined`);
 });
-client.state.on('participantLeave', (participant: string ) => {
-    console.log(`${participant} Left`);
+client.state.on('participantLeave', (participantSessionID: string, participant: IParticipant ) => {
+    console.log(`${participant.username}(${participantSessionID}) Left`);
 });
 /* tslint:enable:no-console */

--- a/src/state/IState.ts
+++ b/src/state/IState.ts
@@ -44,7 +44,7 @@ export interface IState extends EventEmitter {
     /**
      * Fired when a participant leaves.
      */
-    on(event: 'participantLeave', listener: (participantSessionID: string) => void): this;
+    on(event: 'participantLeave', listener: (participantSessionID: string, participant: IParticipant) => void): this;
 
     /**
      * Fired when a scene is deleted.

--- a/src/state/State.ts
+++ b/src/state/State.ts
@@ -146,7 +146,7 @@ export class State extends EventEmitter implements IState {
         this.methodHandler.addHandler('onParticipantLeave', res => {
             res.params.participants.forEach(participant => {
                 this.participants.delete(participant.sessionID);
-                this.emit('participantLeave', participant.sessionID);
+                this.emit('participantLeave', participant.sessionID, participant);
             });
         });
 


### PR DESCRIPTION
From a personal usecase, I needed to store participant data myself to be able to use it on the leave event.
It works but actually is kind of dumb, as it's only to accomodate for that one event.

So why not pass the final participant object instead of only the sessionID?

I added the object as a second parameter though to not break stuff.
But it should maybe get changed to work like the join event (only the participant object) one day, though.