### PR TITLE
Fix/http discovery

### DIFF
--- a/src/Requester.ts
+++ b/src/Requester.ts
@@ -28,7 +28,7 @@ export class Requester implements IRequester {
     }
     private getRequestFn(url: string) {
         //tslint:disable no-http-string
-        if (url.substr(0, 5) === 'http:') {
+        if (url.startsWith('http:')) {
             return http.get;
         }
         //tslint:enable no-http-string

--- a/src/Requester.ts
+++ b/src/Requester.ts
@@ -1,3 +1,4 @@
+import * as http from 'http';
 import * as https from 'https';
 import { HTTPError, TimeoutError } from './errors';
 
@@ -8,7 +9,7 @@ export interface IRequester {
 export class Requester implements IRequester {
     public request(url: string): Promise<any> {
         return new Promise((resolve, reject) => {
-            const req = https.get(url, res => {
+            const req = this.getRequestFn(url)(url, res => {
                 if (res.statusCode !== 200) {
                     reject(
                         new HTTPError(res.statusCode, res.statusMessage, res),
@@ -24,5 +25,13 @@ export class Requester implements IRequester {
                 reject(new TimeoutError('Request timed out')),
             );
         });
+    }
+    private getRequestFn(url: string) {
+        //tslint:disable no-http-string
+        if (url.substr(0, 5) === 'http:') {
+          return http.get;
+        }
+        //tslint:enable no-http-string
+        return https.get;
     }
 }

--- a/src/Requester.ts
+++ b/src/Requester.ts
@@ -29,7 +29,7 @@ export class Requester implements IRequester {
     private getRequestFn(url: string) {
         //tslint:disable no-http-string
         if (url.substr(0, 5) === 'http:') {
-          return http.get;
+            return http.get;
         }
         //tslint:enable no-http-string
         return https.get;


### PR DESCRIPTION
For a local setup for development, the discovery url would be the local copy of the interactive service folder. In most cases this ends up being `http`. This used to throw an error but now will swap out the use of `http` or `https` to match the input discovery url. 