### PR TITLE
feat(socket): use round robin for endpoints when the connection fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4195,15 +4195,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -4238,6 +4229,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/src/Client.spec.ts
+++ b/src/Client.spec.ts
@@ -11,7 +11,7 @@ setWebSocket(WebSocket);
 const port = process.env.SERVER_PORT || 1339;
 
 describe('client', () => {
-    const url = `ws://127.0.0.1:${port}/`;
+    const urls = [`ws://127.0.0.1:${port}/`];
     let client: Client;
     let server: WebSocket.Server;
     let ws: WebSocket;
@@ -24,7 +24,7 @@ describe('client', () => {
     }
 
     const socketOptions = {
-        url,
+        urls,
     };
     function createClient(): Client {
         return new Client(ClientType.GameClient);

--- a/src/GameClient.ts
+++ b/src/GameClient.ts
@@ -58,7 +58,7 @@ export class GameClient extends Client {
             .then(endpoints => {
                 return super.open({
                     authToken: options.authToken,
-                    url: endpoints[0].address,
+                    urls: endpoints.map(({ address }) => address),
                     extraHeaders: extraHeaders,
                 });
             });

--- a/src/ParticipantClient.ts
+++ b/src/ParticipantClient.ts
@@ -31,7 +31,7 @@ export class ParticipantClient extends Client {
 
     public open(options: IParticipantOptions): Promise<this> {
         return super.open({
-            url: options.url,
+            urls: [options.url],
             reconnectChecker: options.reconnectChecker,
             queryParams: {
                 'x-protocol-version': '2.0',

--- a/src/wire/Socket.ts
+++ b/src/wire/Socket.ts
@@ -13,7 +13,7 @@ import {
 /**
  * Close codes that are deemed to be recoverable by the reconnection policy
  */
-export const recoverableCloseCodes = [1000, 1011];
+export const recoverableCloseCodes = [1000, 1001, 1006, 1011, 1012];
 
 //We don't support lz4 due to time constraints right now
 export type CompressionScheme = 'none' | 'gzip';
@@ -27,8 +27,8 @@ export interface ISocketOptions {
     reconnectionPolicy?: IReconnectionPolicy;
     autoReconnect?: boolean;
 
-    // Websocket URL to connect to, defaults to <TODO>
-    url?: string;
+    // Array of possible websocket URLs to connect to.
+    urls?: string[];
 
     //compression scheme, defaults to none, Will remain none until pako typings are updated
     compressionScheme?: CompressionScheme;
@@ -92,7 +92,7 @@ export enum SocketState {
 
 function getDefaults(): ISocketOptions {
     return {
-        url: '',
+        urls: [],
         replyTimeout: 10000,
         compressionScheme: 'none',
         autoReconnect: true,
@@ -119,6 +119,7 @@ export class InteractiveSocket extends EventEmitter {
     private socket: any;
     private queue: Set<Packet> = new Set<Packet>();
     private lastSequenceNumber = 0;
+    private endpointIndex = 0;
 
     constructor(options: ISocketOptions = {}) {
         super();
@@ -213,7 +214,7 @@ export class InteractiveSocket extends EventEmitter {
             headers,
         };
 
-        const url = Url.parse(this.options.url, true);
+        const url = Url.parse(this.getURL(), true);
         // Clear out search so it populates query using the query
         // https://nodejs.org/api/url.html#url_url_format_urlobject
         url.search = null;
@@ -367,6 +368,14 @@ export class InteractiveSocket extends EventEmitter {
 
         this.emit('send', payload);
         this.socket.send(payload);
+    }
+
+    private getURL(): string {
+        const addresses = this.options.urls;
+        if (this.endpointIndex >= addresses.length) {
+            this.endpointIndex = 0;
+        }
+        return addresses[this.endpointIndex++];
     }
 
     private extractMessage(packet: string | Buffer) {


### PR DESCRIPTION
If the connection to interactive is dropped, connect to the next server served by `/interactive/hosts` (and cycle through them). Also expands the recoverable error codes to include CloudFlare errors, server restarts, etc.