### PR TITLE
fix(websocket): Fix websocket auth in browsers

### DIFF
--- a/src/wire/Socket.ts
+++ b/src/wire/Socket.ts
@@ -202,9 +202,14 @@ export class InteractiveSocket extends EventEmitter {
         if (this.options.authToken) {
             extras.headers['Authorization'] = `Bearer ${this.options.authToken}`;
         }
-        url.query = Object.assign({}, url.query, this.options.queryParams);
 
-        this.socket = new InteractiveSocket.WebSocket(Url.format(url), [], extras);
+        if (WebSocket === InteractiveSocket.WebSocket) {
+            url.query = Object.assign({}, url.query, this.options.queryParams, extras.headers);
+            this.socket = new InteractiveSocket.WebSocket(Url.format(url));
+        } else {
+            url.query = Object.assign({}, url.query, this.options.queryParams);
+            this.socket = new InteractiveSocket.WebSocket(Url.format(url), [], extras);
+        }
 
         this.state = SocketState.Connecting;
 

--- a/src/wire/Socket.ts
+++ b/src/wire/Socket.ts
@@ -203,7 +203,7 @@ export class InteractiveSocket extends EventEmitter {
             extras.headers['Authorization'] = `Bearer ${this.options.authToken}`;
         }
 
-        if (WebSocket === InteractiveSocket.WebSocket) {
+        if (typeof WebSocket === 'function' && WebSocket === InteractiveSocket.WebSocket) {
             url.query = Object.assign({}, url.query, this.options.queryParams, extras.headers);
             this.socket = new InteractiveSocket.WebSocket(Url.format(url));
         } else {


### PR DESCRIPTION
Previously we errored out when running in a browser with a 400 code -
because no auth info was supplied. Fix is to take the auth info we would
add to headers, and add to query string instead when working with the
built-in `WebSocket` implementation.

Tested in NodeJS and Browser (Firefox, Chrome)