### PR TITLE
chore(reference docs): fix typedoc generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm i --save @mixer/interactive-node
 
 ### Authentication
 
-[OAuth 2.0](https://tools.ietf.org/html/rfc6749) is used for authentication. Valid bearer tokens can be passed in the `Client.open` method.
+[OAuth 2.0](https://tools.ietf.org/html/rfc6749) is used for authentication. Valid bearer tokens can be passed in the [Client.open](https://mixer.github.io/interactive-node/classes/client.html#open) method.
 
 For more information about Mixer's OAuth visit the [OAuth reference page](https://dev.mixer.com/reference/oauth/index.html) on our developer site.
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "npm run build",
     "postpublish": "npm run docs:publish",
     "lint": "tslint -c tslint.json --project tsconfig.json \"src/**/*.ts\" \"test/**/*.ts\"",
-    "docs:build": "rimraf docs && typedoc --exclude \"{*.spec.ts,**/node_modules/**}\" --out docs/ --mode file --excludeNotExported --excludePrivate --excludeExternals --tsconfig tsconfig.json ./src/index.ts && node doc-postprocess.js",
+    "docs:build": "rimraf docs && typedoc --exclude \"{*.spec.ts,**/node_modules/**}\" --out docs/ --mode file --excludeNotExported --excludePrivate --excludeExternals --tsconfig tsconfig.json ./src && node doc-postprocess.js",
     "docs:publish": "npm run docs:build && gh-pages -d docs -s **"
   },
   "repository": {


### PR DESCRIPTION
#108 Reference docs were not generated by TypeDoc when the   `docs:build` used `./src/index.ts` as its path to project. Swapping to `./src` fixes this.